### PR TITLE
Custom player voice — Phase 0 + α.1-α.4c (#83, #84)

### DIFF
--- a/soh/include/functions.h
+++ b/soh/include/functions.h
@@ -2009,6 +2009,10 @@ SoundFontSound* Audio_InstrumentGetSound(Instrument* instrument, s32 semitone);
 Instrument* Audio_GetInstrumentInner(s32 fontId, s32 instId);
 Drum* Audio_GetDrum(s32 fontId, s32 drumId);
 SoundFontSound* Audio_GetSfx(s32 fontId, s32 sfxId);
+// Flotilla #83/#84 α.4c — voice substitution wrapper around Audio_GetSfx.
+// Audio-thread call site at audio_seqplayer.c:686. See audio_playback.c
+// implementation for full semantics.
+SoundFontSound* Audio_GetSfxOverride(struct SequenceChannel* channel, s32 fontId, s32 sfxId);
 s32 Audio_SetFontInstrument(s32 instrumentType, s32 fontId, s32 index, void* value);
 void Audio_SeqLayerDecayRelease(SequenceLayer* layer, s32 target);
 void Audio_SeqLayerNoteDecay(SequenceLayer* layer);

--- a/soh/include/variables.h
+++ b/soh/include/variables.h
@@ -228,6 +228,12 @@ extern "C"
 	extern u16 gAudioSfxSwapSource[10];
 	extern u16 gAudioSfxSwapTarget[10];
 	extern u8 gAudioSfxSwapMode[10];
+	// Flotilla #83/#84 — current voice-emission emitter clientId (game-thread
+	// global). Set immediately before Audio_PlaySoundGeneral; the call captures
+	// it into SoundRequest::emitterClientId. Reset to 0 after. SoH game logic
+	// is single-threaded so a plain global is safe; the audio thread reads
+	// the captured value only via SoundRequest, never via this global.
+	extern u32 gAnchorCurrentEmitterClientId;
 	extern ActiveSequence gActiveSeqs[4];
 	extern AudioContext gAudioContext;
 	extern void(*D_801755D0)(void);

--- a/soh/include/z64audio.h
+++ b/soh/include/z64audio.h
@@ -1054,7 +1054,8 @@ typedef struct {
     /* 0x2D */ u8       next;
     /* 0x2E */ u8       channelIdx;
     /* 0x2F */ u8       unk_2F;
-} SoundBankEntry; // size = 0x30
+    /* 0x30 */ u32      emitterClientId; // Flotilla #83/#84 — copied from SoundRequest at enqueue; threaded to audio thread in Phase α.3
+} SoundBankEntry; // size = 0x34
 
 /*
  * SFX IDs

--- a/soh/include/z64audio.h
+++ b/soh/include/z64audio.h
@@ -417,8 +417,10 @@ typedef struct SequenceChannel {
     /* 0xC4 */ s8 soundScriptIO[8]; // bridge between sound script and audio lib, "io ports"
     /* 0xCC */ s16* filter;
     /* 0xD0 */ Stereo stereo;
-    /* 0xD4 */ u32 emitterClientId; // Flotilla #83/#84 — set by CHAN_UPD_ANCHOR_EMITTER from the game thread before each SFX dispatch; read on the audio thread at Audio_GetSfx interception (Phase α.4) to drive per-emitter sample substitution. 0 = no Anchor context / use vanilla.
-} SequenceChannel; // size = 0xD8
+    /* 0xD4 */ u32 emitterClientId; // Flotilla #83/#84 — set by CHAN_UPD_ANCHOR_EMITTER from the game thread before each SFX dispatch; read on the audio thread at Audio_GetSfxOverride interception (Phase α.4c) to drive per-emitter sample substitution. 0 = no Anchor context / use vanilla.
+    /* 0xD8 */ u8  emitterSfxBank;  // Flotilla #83/#84 — bank index 0-6 of the in-flight SFX; 0xFF means "no Anchor context" (BGM channels, or pre-emission). Gate for the voice substitution (only bank=6=BANK_VOICE substitutes).
+    /* 0xDC */ SoundFontSound emitterOverrideSlot; // Per-channel scratch SoundFontSound returned by Audio_GetSfxOverride when a sample substitution hits. Holds {customSample*, vanillaTuning} for the in-flight emission.
+} SequenceChannel; // size grows by emitterSfxBank + alignment + SoundFontSound; depends on platform pointer width
 
 // Flotilla #83/#84 voice substitution (Phase α.3) channel-update opcode.
 // Game-thread call site: code_800F7260.c::Audio_PlayActiveSounds queues this

--- a/soh/include/z64audio.h
+++ b/soh/include/z64audio.h
@@ -417,7 +417,18 @@ typedef struct SequenceChannel {
     /* 0xC4 */ s8 soundScriptIO[8]; // bridge between sound script and audio lib, "io ports"
     /* 0xCC */ s16* filter;
     /* 0xD0 */ Stereo stereo;
-} SequenceChannel; // size = 0xD4
+    /* 0xD4 */ u32 emitterClientId; // Flotilla #83/#84 — set by CHAN_UPD_ANCHOR_EMITTER from the game thread before each SFX dispatch; read on the audio thread at Audio_GetSfx interception (Phase α.4) to drive per-emitter sample substitution. 0 = no Anchor context / use vanilla.
+} SequenceChannel; // size = 0xD8
+
+// Flotilla #83/#84 voice substitution (Phase α.3) channel-update opcode.
+// Game-thread call site: code_800F7260.c::Audio_PlayActiveSounds queues this
+// just before the SFX playback start cmd so the audio thread has set
+// channel->emitterClientId by the time Audio_GetSfx fires for this
+// emission. cmd->data carries the u32 emitterClientId.
+//
+// Defined outside the file-local ChannelUpdateType enum in code_800E4FE0.c
+// so the queue site (code_800F7260.c) can reference the same constant.
+#define CHAN_UPD_ANCHOR_EMITTER 15
 
 // Might also be known as a Track, according to sm64 debug strings (?).
 typedef struct SequenceLayer {

--- a/soh/soh/Enhancements/audio/AudioCollection.cpp
+++ b/soh/soh/Enhancements/audio/AudioCollection.cpp
@@ -347,6 +347,38 @@ std::string AudioCollection::GetCvarLockKey(std::string sfxKey) {
     return prefix + sfxKey + ".locked";
 }
 
+// --- VoicePack (issue #83, #84) helpers -----------------------------------
+
+uint16_t AudioCollection::FindSeqIdBySfxKey(const std::string& sfxKey) const {
+    for (const auto& [seqId, info] : sequenceMap) {
+        if (info.sfxKey == sfxKey) {
+            return seqId;
+        }
+    }
+    return 0;
+}
+
+void AudioCollection::AddCustomVoiceEntry(uint16_t seqNum, const std::string& label,
+                                           const std::string& sfxKey) {
+    // canBeUsedAsReplacement=false hides these entries from the Audio Editor's
+    // Voices tab dropdown.  The actual playback substitution path is the
+    // D4+D7 hybrid (per-emitter sample override at Audio_GetSfx interception),
+    // not GetReplacementSequence — so users selecting these entries via the
+    // editor would be a dead end (and previously crashed the SFX dispatch
+    // for 0xF000+ seqNums).  Registration here keeps the sequenceMap honest
+    // for any future read-side consumers (Audio Editor diagnostic display,
+    // log inspection, debug tools).
+    SequenceInfo info = { seqNum, label, sfxKey, SEQ_VOICE,
+                          /*canBeReplaced=*/false, /*canBeUsedAsReplacement=*/false };
+    sequenceMap[seqNum] = info;  // insert_or_assign semantics
+}
+
+void AudioCollection::RemoveCustomEntry(uint16_t seqNum) {
+    sequenceMap.erase(seqNum);
+}
+
+// --------------------------------------------------------------------------
+
 void AudioCollection::AddToCollection(char* otrPath, uint16_t seqNum) {
     std::string fileName = std::filesystem::path(otrPath).filename().string();
     std::vector<std::string> splitFileName = StringHelper::Split(fileName, "_");

--- a/soh/soh/Enhancements/audio/AudioCollection.h
+++ b/soh/soh/Enhancements/audio/AudioCollection.h
@@ -68,6 +68,24 @@ class AudioCollection {
     size_t SequenceMapSize();
     std::string GetCvarKey(std::string sfxKey);
     std::string GetCvarLockKey(std::string sfxKey);
+
+    // --- VoicePack (issue #83, #84) support ---
+    // Reverse lookup: given an sfxKey like "NA_SE_VO_LI_SWORD_N", returns the
+    // matching seqId.  Returns 0 if not found.
+    uint16_t FindSeqIdBySfxKey(const std::string& sfxKey) const;
+
+    // Registers a custom voice entry not tied to a music-pack filename scheme.
+    // Used by VoicePack when loading VRP-style samples for Audio Editor
+    // visibility (the SEQ_VOICE entry shows up in the editor's Voices tab).
+    // canBeUsedAsReplacement=false because the actual playback substitution
+    // is wired via the D4+D7 hybrid path (see Plans / Analysis docs), not
+    // via GetReplacementSequence.
+    void AddCustomVoiceEntry(uint16_t seqNum, const std::string& label,
+                              const std::string& sfxKey);
+
+    // Removes a custom entry previously added via AddCustomVoiceEntry.
+    // No-op if the entry does not exist.
+    void RemoveCustomEntry(uint16_t seqNum);
 };
 #else
 void AudioCollection_AddToCollection(char* otrPath, uint16_t seqNum);

--- a/soh/soh/Enhancements/audio/VoicePack.cpp
+++ b/soh/soh/Enhancements/audio/VoicePack.cpp
@@ -1,0 +1,352 @@
+#include "VoicePack.h"
+#include "AudioCollection.h"
+
+#include <libultraship/libultraship.h>
+#include <ship/Context.h>
+#include <ship/resource/archive/Archive.h>
+#include <ship/resource/archive/OtrArchive.h>
+#include <ship/resource/archive/O2rArchive.h>
+#include <spdlog/spdlog.h>
+#include <nlohmann/json.hpp>
+
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "soh/OTRGlobals.h"  // appShortName
+
+// Voice-pack loader (B2).  See VoicePack.h for the high-level architecture.
+//
+// PHASE 0 (THIS FILE): single-pack model ported from the WIP scaffolding.
+// Loads samples into the ResourceManager cache under per-pack unique keys
+// — that's the D7 cache-isolation layer of the D4+D7 hybrid, already
+// working.  Phase 1 will:
+//   - Replace the single ActivePack with `(clientId → LoadedPack)` map.
+//   - Wire peer-pack load/unload from the UPDATE_CLIENT_STATE handler.
+//   - Add the per-emitter sample lookup table (D4 layer).
+//
+// PHASE 4 will add the Audio_GetSfx interception that consults the lookup
+// and substitutes the cached SoundFontSample* when an override exists.
+//
+// Until Phase 4 lands, voice emissions still play the vanilla samples.  The
+// pack's samples sit in the resource cache, registered with AudioCollection
+// for Audio Editor visibility, but not yet substituted at playback time.
+
+namespace {
+
+struct LoadedSample {
+    std::string label;             // VRP sample name (e.g. "Adult Link - Attack 3")
+    std::string sfxKey;            // resolved SoH sfxKey (e.g. "NA_SE_VO_LI_SWORD_N")
+    std::string cacheKey;          // ResourceManager key (player-voices/<folder>/<path>)
+    uint16_t    vanillaSeqId;      // resolved vanilla voice id we're overriding
+    uint16_t    displayOnlySeqNum; // pack-assigned seqNum (Audio Editor display only)
+};
+
+struct LoadedPack {
+    std::string folderName;
+    // For the D4 substitution layer (Phase 1+ wiring):
+    // vanilla sfxId → resource cache key of the override sample.
+    std::unordered_map<uint16_t, std::string> sampleOverridesByVanillaSfxId;
+    // Full record of what we registered — used on unload.
+    std::vector<LoadedSample> loadedSamples;
+};
+
+// Audio-Editor-display-only seqNum allocator.  These seqNums are NOT used
+// for playback substitution (that path crashed — see analysis doc §2 root
+// cause).  They exist solely so AudioCollection's sequenceMap has an entry
+// for each loaded pack sample (informational; aids Audio Editor diagnostics).
+constexpr uint16_t kVoicePackDisplaySeqNumBase = 0xF000;
+
+std::mutex                                   gStateMutex;
+std::unique_ptr<LoadedPack>                  gActivePack;                 // local pack (null = Default Voices)
+std::unordered_map<std::string, std::string> gDefaultTranslation;         // VRP label → SoH sfxKey
+bool                                         gDefaultTranslationLoaded = false;
+uint16_t                                     gNextDisplaySeqNum = kVoicePackDisplaySeqNumBase;
+
+// ---------------------------------------------------------------------------
+// Translation table I/O
+// ---------------------------------------------------------------------------
+
+void ParseTranslationJson(const nlohmann::json& j,
+                          std::unordered_map<std::string, std::string>& out) {
+    if (!j.is_object()) {
+        SPDLOG_WARN("[VoicePack] translation JSON root is not an object; ignoring");
+        return;
+    }
+    for (auto it = j.begin(); it != j.end(); ++it) {
+        if (!it.value().is_string()) {
+            SPDLOG_WARN("[VoicePack] translation entry \"{}\" has non-string value; skipping",
+                        it.key());
+            continue;
+        }
+        out[it.key()] = it.value().get<std::string>();
+    }
+}
+
+void LoadDefaultTranslationIfNeeded() {
+    if (gDefaultTranslationLoaded) return;
+    gDefaultTranslationLoaded = true;  // always flip even on failure so we don't retry
+
+    const std::string voiceRoot =
+        Ship::Context::LocateFileAcrossAppDirs("player-voices", appShortName);
+    const std::filesystem::path path =
+        std::filesystem::path(voiceRoot) / "_default_translation.json";
+
+    if (!std::filesystem::exists(path)) {
+        SPDLOG_INFO("[VoicePack] no default translation at \"{}\" "
+                    "(packs without a manifest will skip all samples)",
+                    path.generic_string());
+        return;
+    }
+
+    try {
+        std::ifstream f(path);
+        nlohmann::json j;
+        f >> j;
+        ParseTranslationJson(j, gDefaultTranslation);
+        SPDLOG_INFO("[VoicePack] loaded default translation: {} entries from \"{}\"",
+                    gDefaultTranslation.size(), path.generic_string());
+    } catch (const std::exception& e) {
+        SPDLOG_WARN("[VoicePack] failed to parse default translation \"{}\": {}",
+                    path.generic_string(), e.what());
+    }
+}
+
+std::unordered_map<std::string, std::string>
+ReadPackManifest(const std::shared_ptr<Ship::Archive>& archive) {
+    std::unordered_map<std::string, std::string> out;
+    if (!archive) return out;
+
+    auto file = archive->LoadFile("translation.json");
+    if (!file || !file->Buffer || file->Buffer->empty()) return out;
+
+    try {
+        auto j = nlohmann::json::parse(file->Buffer->begin(), file->Buffer->end());
+        ParseTranslationJson(j, out);
+        SPDLOG_INFO("[VoicePack] pack manifest \"translation.json\" parsed: {} entries",
+                    out.size());
+    } catch (const std::exception& e) {
+        SPDLOG_WARN("[VoicePack] pack manifest \"translation.json\" parse failed: {}", e.what());
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Sample registration
+// ---------------------------------------------------------------------------
+
+// Preloads the sample into the ResourceManager cache under a per-pack-unique
+// key (D7 cache-isolation discipline; mirror of BakedPlayerModel's
+// `coopchar/<folder>/<altPath>` pattern).  Also registers a SequenceInfo
+// for Audio Editor display visibility.
+//
+// Returns true on success.  Caller updates pack-level bookkeeping.
+bool RegisterSample(const std::string& packFolder,
+                    const std::string& archiveEntryPath,
+                    const std::string& vrpLabel,
+                    const std::string& sfxKey,
+                    uint16_t displaySeqNum,
+                    const std::shared_ptr<Ship::Archive>& archive,
+                    std::string& outCacheKey) {
+    auto file = archive->LoadFile(archiveEntryPath);
+    if (!file || !file->Buffer) {
+        SPDLOG_WARN("[VoicePack]   sample file not readable: \"{}\"", archiveEntryPath);
+        return false;
+    }
+
+    auto resourceMgr = Ship::Context::GetInstance()->GetResourceManager();
+    auto loader      = resourceMgr->GetResourceLoader();
+
+    // Unique cache key — switching packs that share archive paths cannot
+    // collide.  This is the D7 cache-isolation layer of the D4+D7 hybrid.
+    outCacheKey = "player-voices/" + packFolder + "/" + archiveEntryPath;
+    auto resource = loader->LoadResource(outCacheKey, file);
+    if (!resource) {
+        SPDLOG_WARN("[VoicePack]   LoadResource failed for \"{}\"", outCacheKey);
+        return false;
+    }
+    resourceMgr->SetCachedResource(outCacheKey, resource);
+
+    // Audio Editor display registration (informational only — the playback
+    // substitution path is D4 via per-emitter table consulted at
+    // Audio_GetSfx, NOT this seqNum).
+    std::string label = "[" + packFolder + "] " + vrpLabel + " -> " + sfxKey;
+    AudioCollection::Instance->AddCustomVoiceEntry(displaySeqNum, label, sfxKey);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Pack lifecycle
+// ---------------------------------------------------------------------------
+
+void UnloadCurrentPack_Locked() {
+    if (!gActivePack) return;
+    for (const auto& s : gActivePack->loadedSamples) {
+        AudioCollection::Instance->RemoveCustomEntry(s.displayOnlySeqNum);
+    }
+    SPDLOG_INFO("[VoicePack] unloaded pack \"{}\" ({} samples)",
+                gActivePack->folderName, gActivePack->loadedSamples.size());
+    gActivePack.reset();
+    gNextDisplaySeqNum = kVoicePackDisplaySeqNumBase;
+}
+
+std::shared_ptr<Ship::Archive> OpenTransient(const std::string& archivePath,
+                                              const std::string& ext) {
+    std::shared_ptr<Ship::Archive> archive;
+    if (ext == ".o2r" || ext == ".zip") {
+        archive = std::make_shared<Ship::O2rArchive>(archivePath);
+    } else {
+        archive = std::make_shared<Ship::OtrArchive>(archivePath);
+    }
+    archive->Load();
+    return archive->IsLoaded() ? archive : nullptr;
+}
+
+void LoadPackArchive(const std::string& packFolder,
+                     const std::shared_ptr<Ship::Archive>& archive,
+                     const std::unordered_map<std::string, std::string>& translation,
+                     LoadedPack& pack) {
+    auto files = archive->ListFiles();
+    if (!files) return;
+
+    constexpr const char* kSamplePrefix = "audio/samples/";
+    constexpr const char* kMetaSuffix   = "_META";
+
+    int loaded = 0;
+    int skippedUnmapped = 0;
+    int skippedUnresolvedKey = 0;
+
+    for (auto& [hash, path] : *files) {
+        if (path.rfind(kSamplePrefix, 0) != 0) continue;
+        if (path.size() <= std::strlen(kMetaSuffix) ||
+            path.compare(path.size() - std::strlen(kMetaSuffix), std::strlen(kMetaSuffix),
+                         kMetaSuffix) != 0) {
+            continue;
+        }
+        const std::string vrpLabel =
+            path.substr(std::strlen(kSamplePrefix),
+                        path.size() - std::strlen(kSamplePrefix) - std::strlen(kMetaSuffix));
+
+        auto trIt = translation.find(vrpLabel);
+        if (trIt == translation.end()) {
+            skippedUnmapped++;
+            continue;
+        }
+        const std::string& sfxKey = trIt->second;
+
+        uint16_t vanillaSeqId = AudioCollection::Instance->FindSeqIdBySfxKey(sfxKey);
+        if (vanillaSeqId == 0) {
+            SPDLOG_WARN("[VoicePack]   sfxKey \"{}\" from translation doesn't match any "
+                        "entry in AudioCollection::sequenceMap — skipping sample \"{}\"",
+                        sfxKey, vrpLabel);
+            skippedUnresolvedKey++;
+            continue;
+        }
+
+        const uint16_t displaySeqNum = gNextDisplaySeqNum++;
+        std::string cacheKey;
+        if (!RegisterSample(packFolder, path, vrpLabel, sfxKey,
+                            displaySeqNum, archive, cacheKey)) {
+            continue;
+        }
+
+        pack.loadedSamples.push_back({ vrpLabel, sfxKey, cacheKey,
+                                        vanillaSeqId, displaySeqNum });
+        pack.sampleOverridesByVanillaSfxId[vanillaSeqId] = cacheKey;
+        loaded++;
+    }
+
+    SPDLOG_INFO("[VoicePack]   archive \"{}\": {} samples loaded, {} unmapped, {} unresolved sfxKey",
+                archive->GetPath(), loaded, skippedUnmapped, skippedUnresolvedKey);
+}
+
+void LoadPack_Locked(const std::string& folder) {
+    LoadDefaultTranslationIfNeeded();
+
+    const std::string voiceRoot =
+        Ship::Context::LocateFileAcrossAppDirs("player-voices", appShortName);
+    const std::filesystem::path charDir = std::filesystem::path(voiceRoot) / folder;
+    if (!std::filesystem::exists(charDir) || !std::filesystem::is_directory(charDir)) {
+        SPDLOG_WARN("[VoicePack] folder \"{}\" does not exist under \"{}\"",
+                    folder, voiceRoot);
+        return;
+    }
+
+    auto pack = std::make_unique<LoadedPack>();
+    pack->folderName = folder;
+
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(charDir)) {
+        if (entry.is_directory()) continue;
+        const std::string ext = entry.path().extension().generic_string();
+        if (ext != ".otr" && ext != ".o2r") continue;
+
+        auto archive = OpenTransient(entry.path().generic_string(), ext);
+        if (!archive) {
+            SPDLOG_WARN("[VoicePack]   failed to open \"{}\"", entry.path().generic_string());
+            continue;
+        }
+
+        // Per-pack manifest overlays the default translation.  Pack's keys
+        // win on collision.
+        auto translation = gDefaultTranslation;
+        auto packManifest = ReadPackManifest(archive);
+        for (auto& [k, v] : packManifest) translation[k] = v;
+
+        LoadPackArchive(folder, archive, translation, *pack);
+    }
+
+    SPDLOG_INFO("[VoicePack] loaded pack \"{}\": {} samples, {} vanilla ids overridden",
+                folder, pack->loadedSamples.size(), pack->sampleOverridesByVanillaSfxId.size());
+
+    gActivePack = std::move(pack);
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+namespace SOH {
+namespace VoicePack {
+
+void OnAudioModChanged(const std::string& folder) {
+    std::scoped_lock lock(gStateMutex);
+    UnloadCurrentPack_Locked();
+    if (folder.empty()) {
+        SPDLOG_INFO("[VoicePack] Default Voices selected");
+        return;
+    }
+    LoadPack_Locked(folder);
+}
+
+uint16_t GetReplacement(uint16_t seqId) {
+    // LEGACY — see header.  The original WIP wired this into
+    // AudioCollection::GetReplacementSequence; that direction crashed for
+    // 0xF000+ custom seqNums because the SFX dispatch path indexes the
+    // fixed-size compile-time gSoundParams[7] table (audio_sound_params.c:238).
+    //
+    // The D4+D7 substitution path consults a per-emitter sample lookup at
+    // Audio_GetSfx time on the game thread, not via this function.  Always
+    // returns 0 here; the call site in GetReplacementSequence is NOT ported
+    // from the WIP either, so nothing depends on this.  Symbol remains for
+    // ABI/link compatibility during the Phase 1–4 wire-in.
+    (void)seqId;
+    return 0;
+}
+
+} // namespace VoicePack
+} // namespace SOH
+
+extern "C" void VoicePack_OnAudioModChanged(const char* folder) {
+    SOH::VoicePack::OnAudioModChanged(folder ? std::string(folder) : std::string());
+}
+
+extern "C" uint16_t VoicePack_GetReplacement(uint16_t seqId) {
+    return SOH::VoicePack::GetReplacement(seqId);
+}

--- a/soh/soh/Enhancements/audio/VoicePack.cpp
+++ b/soh/soh/Enhancements/audio/VoicePack.cpp
@@ -159,7 +159,7 @@ bool RegisterSample(const std::string& packFolder,
         return false;
     }
 
-    auto resourceMgr = Ship::Context::GetInstance()->GetResourceManager();
+    auto resourceMgr = Ship::Context::GetRawInstance()->GetResourceManager();
     auto loader      = resourceMgr->GetResourceLoader();
 
     // Unique cache key — switching packs that share archive paths cannot

--- a/soh/soh/Enhancements/audio/VoicePack.cpp
+++ b/soh/soh/Enhancements/audio/VoicePack.cpp
@@ -19,54 +19,65 @@
 #include <vector>
 
 #include "soh/OTRGlobals.h"  // appShortName
+#include "soh/resource/type/AudioSample.h"  // SOH::AudioSample + SOH::Sample
 
-// Voice-pack loader (B2).  See VoicePack.h for the high-level architecture.
+// Voice-pack loader (B2) — Phase α.4a/b — multi-pack + lookup.
 //
-// PHASE 0 (THIS FILE): single-pack model ported from the WIP scaffolding.
-// Loads samples into the ResourceManager cache under per-pack unique keys
-// — that's the D7 cache-isolation layer of the D4+D7 hybrid, already
-// working.  Phase 1 will:
-//   - Replace the single ActivePack with `(clientId → LoadedPack)` map.
-//   - Wire peer-pack load/unload from the UPDATE_CLIENT_STATE handler.
-//   - Add the per-emitter sample lookup table (D4 layer).
+// Phase α.1-α.3 (already shipped) threaded emitterClientId from emission
+// site → SoundRequest → SoundBankEntry → audio-thread SequenceChannel.
+// Phase α.4 (this file) populates the substitution table that the audio
+// thread will consult at Audio_GetSfx interception (Phase α.4c).
 //
-// PHASE 4 will add the Audio_GetSfx interception that consults the lookup
-// and substitutes the cached SoundFontSample* when an override exists.
+// Multi-pack: gLocalPack (single, tied to the local CVar) and
+// gPeerPacks[clientId] (one per remote player). Local pack loads from the
+// dropdown change handler; peer packs load from the UPDATE_CLIENT_STATE
+// receive handler.
 //
-// Until Phase 4 lands, voice emissions still play the vanilla samples.  The
-// pack's samples sit in the resource cache, registered with AudioCollection
-// for Audio Editor visibility, but not yet substituted at playback time.
+// Sample lifetime: each LoadedSample owns a shared_ptr<SOH::AudioSample>
+// returned by the resource loader. The raw SOH::Sample* (used for the
+// audio-thread lookup) is stable as long as the shared_ptr is held.
+// Unloading a pack drops the shared_ptrs (after also dropping the lookup
+// entries) — no dangling pointers.
+
+extern "C" uint32_t Anchor_GetLocalEmitterClientId(void);
 
 namespace {
 
 struct LoadedSample {
-    std::string label;             // VRP sample name (e.g. "Adult Link - Attack 3")
-    std::string sfxKey;            // resolved SoH sfxKey (e.g. "NA_SE_VO_LI_SWORD_N")
-    std::string cacheKey;          // ResourceManager key (player-voices/<folder>/<path>)
-    uint16_t    vanillaSeqId;      // resolved vanilla voice id we're overriding
-    uint16_t    displayOnlySeqNum; // pack-assigned seqNum (Audio Editor display only)
+    std::string                      vrpLabel;             // VRP sample name
+    std::string                      sfxKey;               // resolved SoH sfxKey (e.g. NA_SE_VO_LI_SWORD_N)
+    std::string                      cacheKey;             // ResourceManager key (D7 isolation)
+    uint16_t                         vanillaSeqId;         // vanilla voice id being overridden
+    uint16_t                         displayOnlySeqNum;    // Audio Editor display registration id
+    std::shared_ptr<SOH::AudioSample> resource;            // lifetime owner — keeps Sample* alive
+    SOH::Sample*                     samplePtr;            // stable pointer into resource->sample
 };
 
 struct LoadedPack {
-    std::string folderName;
-    // For the D4 substitution layer (Phase 1+ wiring):
-    // vanilla sfxId → resource cache key of the override sample.
-    std::unordered_map<uint16_t, std::string> sampleOverridesByVanillaSfxId;
-    // Full record of what we registered — used on unload.
-    std::vector<LoadedSample> loadedSamples;
+    std::string                                   folderName;
+    std::vector<LoadedSample>                     loadedSamples;
+    // Lookup: vanilla sfxId → Sample*. Populated at load time, consumed by
+    // GetSampleOverride. Phase α.5 (variant pools) will switch this to
+    // unordered_map<uint16_t, std::vector<SOH::Sample*>>.
+    std::unordered_map<uint16_t, SOH::Sample*>    sampleByVanillaSfxId;
 };
 
-// Audio-Editor-display-only seqNum allocator.  These seqNums are NOT used
-// for playback substitution (that path crashed — see analysis doc §2 root
-// cause).  They exist solely so AudioCollection's sequenceMap has an entry
-// for each loaded pack sample (informational; aids Audio Editor diagnostics).
+// Opaque type for the public API. Currently equals LoadedSample::samplePtr;
+// Phase α.5 will turn this into a small wrapper that also carries variant-
+// pool selection state. For now, just an alias — but kept as a separate
+// type so the header doesn't leak SOH::Sample.
+struct SampleOverrideImpl {
+    SOH::Sample* sample;
+};
+
 constexpr uint16_t kVoicePackDisplaySeqNumBase = 0xF000;
 
-std::mutex                                   gStateMutex;
-std::unique_ptr<LoadedPack>                  gActivePack;                 // local pack (null = Default Voices)
-std::unordered_map<std::string, std::string> gDefaultTranslation;         // VRP label → SoH sfxKey
-bool                                         gDefaultTranslationLoaded = false;
-uint16_t                                     gNextDisplaySeqNum = kVoicePackDisplaySeqNumBase;
+std::recursive_mutex                                       gStateMutex;
+std::unique_ptr<LoadedPack>                                gLocalPack;
+std::unordered_map<uint32_t, std::unique_ptr<LoadedPack>>  gPeerPacks;
+std::unordered_map<std::string, std::string>               gDefaultTranslation;
+bool                                                       gDefaultTranslationLoaded = false;
+uint16_t                                                   gNextDisplaySeqNum        = kVoicePackDisplaySeqNumBase;
 
 // ---------------------------------------------------------------------------
 // Translation table I/O
@@ -90,7 +101,7 @@ void ParseTranslationJson(const nlohmann::json& j,
 
 void LoadDefaultTranslationIfNeeded() {
     if (gDefaultTranslationLoaded) return;
-    gDefaultTranslationLoaded = true;  // always flip even on failure so we don't retry
+    gDefaultTranslationLoaded = true;
 
     const std::string voiceRoot =
         Ship::Context::LocateFileAcrossAppDirs("player-voices", appShortName);
@@ -140,19 +151,13 @@ ReadPackManifest(const std::shared_ptr<Ship::Archive>& archive) {
 // Sample registration
 // ---------------------------------------------------------------------------
 
-// Preloads the sample into the ResourceManager cache under a per-pack-unique
-// key (D7 cache-isolation discipline; mirror of BakedPlayerModel's
-// `coopchar/<folder>/<altPath>` pattern).  Also registers a SequenceInfo
-// for Audio Editor display visibility.
-//
-// Returns true on success.  Caller updates pack-level bookkeeping.
 bool RegisterSample(const std::string& packFolder,
                     const std::string& archiveEntryPath,
                     const std::string& vrpLabel,
                     const std::string& sfxKey,
                     uint16_t displaySeqNum,
                     const std::shared_ptr<Ship::Archive>& archive,
-                    std::string& outCacheKey) {
+                    LoadedSample& outSample) {
     auto file = archive->LoadFile(archiveEntryPath);
     if (!file || !file->Buffer) {
         SPDLOG_WARN("[VoicePack]   sample file not readable: \"{}\"", archiveEntryPath);
@@ -162,38 +167,50 @@ bool RegisterSample(const std::string& packFolder,
     auto resourceMgr = Ship::Context::GetRawInstance()->GetResourceManager();
     auto loader      = resourceMgr->GetResourceLoader();
 
-    // Unique cache key — switching packs that share archive paths cannot
-    // collide.  This is the D7 cache-isolation layer of the D4+D7 hybrid.
-    outCacheKey = "player-voices/" + packFolder + "/" + archiveEntryPath;
-    auto resource = loader->LoadResource(outCacheKey, file);
-    if (!resource) {
-        SPDLOG_WARN("[VoicePack]   LoadResource failed for \"{}\"", outCacheKey);
+    // D7 cache-isolation key: each pack's sample under a unique path so
+    // simultaneously-loaded peer packs can't collide.
+    const std::string cacheKey =
+        "player-voices/" + packFolder + "/" + archiveEntryPath;
+    auto rawResource = loader->LoadResource(cacheKey, file);
+    if (!rawResource) {
+        SPDLOG_WARN("[VoicePack]   LoadResource failed for \"{}\"", cacheKey);
         return false;
     }
-    resourceMgr->SetCachedResource(outCacheKey, resource);
+    resourceMgr->SetCachedResource(cacheKey, rawResource);
 
-    // Audio Editor display registration (informational only — the playback
-    // substitution path is D4 via per-emitter table consulted at
-    // Audio_GetSfx, NOT this seqNum).
+    // The audio sample factory (AudioSampleFactory.cpp) creates AudioSample
+    // resources for VRP-format files. static_pointer_cast pattern mirrors
+    // AudioSoundFontFactory.cpp:310-315.
+    auto audioSample = std::static_pointer_cast<SOH::AudioSample>(rawResource);
+    if (!audioSample) {
+        SPDLOG_WARN("[VoicePack]   resource for \"{}\" is not AudioSample-typed", cacheKey);
+        return false;
+    }
+    SOH::Sample* samplePtr =
+        static_cast<SOH::Sample*>(audioSample->GetRawPointer());
+    if (samplePtr == nullptr) {
+        SPDLOG_WARN("[VoicePack]   AudioSample for \"{}\" has null GetRawPointer", cacheKey);
+        return false;
+    }
+
+    // Audio Editor display registration (informational; canBeUsedAsReplacement
+    // is false so users don't see them in the substitution dropdown — the
+    // playback path is the per-emitter table, not GetReplacementSequence).
     std::string label = "[" + packFolder + "] " + vrpLabel + " -> " + sfxKey;
     AudioCollection::Instance->AddCustomVoiceEntry(displaySeqNum, label, sfxKey);
+
+    outSample.vrpLabel          = vrpLabel;
+    outSample.sfxKey            = sfxKey;
+    outSample.cacheKey          = cacheKey;
+    outSample.displayOnlySeqNum = displaySeqNum;
+    outSample.resource          = audioSample;  // shared_ptr keeps lifetime
+    outSample.samplePtr         = samplePtr;
     return true;
 }
 
 // ---------------------------------------------------------------------------
 // Pack lifecycle
 // ---------------------------------------------------------------------------
-
-void UnloadCurrentPack_Locked() {
-    if (!gActivePack) return;
-    for (const auto& s : gActivePack->loadedSamples) {
-        AudioCollection::Instance->RemoveCustomEntry(s.displayOnlySeqNum);
-    }
-    SPDLOG_INFO("[VoicePack] unloaded pack \"{}\" ({} samples)",
-                gActivePack->folderName, gActivePack->loadedSamples.size());
-    gActivePack.reset();
-    gNextDisplaySeqNum = kVoicePackDisplaySeqNumBase;
-}
 
 std::shared_ptr<Ship::Archive> OpenTransient(const std::string& archivePath,
                                               const std::string& ext) {
@@ -249,15 +266,15 @@ void LoadPackArchive(const std::string& packFolder,
         }
 
         const uint16_t displaySeqNum = gNextDisplaySeqNum++;
-        std::string cacheKey;
+        LoadedSample loaded_sample;
         if (!RegisterSample(packFolder, path, vrpLabel, sfxKey,
-                            displaySeqNum, archive, cacheKey)) {
+                            displaySeqNum, archive, loaded_sample)) {
             continue;
         }
+        loaded_sample.vanillaSeqId = vanillaSeqId;
 
-        pack.loadedSamples.push_back({ vrpLabel, sfxKey, cacheKey,
-                                        vanillaSeqId, displaySeqNum });
-        pack.sampleOverridesByVanillaSfxId[vanillaSeqId] = cacheKey;
+        pack.sampleByVanillaSfxId[vanillaSeqId] = loaded_sample.samplePtr;
+        pack.loadedSamples.push_back(std::move(loaded_sample));
         loaded++;
     }
 
@@ -265,7 +282,10 @@ void LoadPackArchive(const std::string& packFolder,
                 archive->GetPath(), loaded, skippedUnmapped, skippedUnresolvedKey);
 }
 
-void LoadPack_Locked(const std::string& folder) {
+// Loads a fresh LoadedPack from disk. Caller is responsible for installing
+// the resulting unique_ptr into the right slot (gLocalPack or gPeerPacks).
+// Returns nullptr if the folder doesn't exist or contains no usable archives.
+std::unique_ptr<LoadedPack> LoadPackFromFolder(const std::string& folder) {
     LoadDefaultTranslationIfNeeded();
 
     const std::string voiceRoot =
@@ -274,7 +294,7 @@ void LoadPack_Locked(const std::string& folder) {
     if (!std::filesystem::exists(charDir) || !std::filesystem::is_directory(charDir)) {
         SPDLOG_WARN("[VoicePack] folder \"{}\" does not exist under \"{}\"",
                     folder, voiceRoot);
-        return;
+        return nullptr;
     }
 
     auto pack = std::make_unique<LoadedPack>();
@@ -291,8 +311,6 @@ void LoadPack_Locked(const std::string& folder) {
             continue;
         }
 
-        // Per-pack manifest overlays the default translation.  Pack's keys
-        // win on collision.
         auto translation = gDefaultTranslation;
         auto packManifest = ReadPackManifest(archive);
         for (auto& [k, v] : packManifest) translation[k] = v;
@@ -300,10 +318,21 @@ void LoadPack_Locked(const std::string& folder) {
         LoadPackArchive(folder, archive, translation, *pack);
     }
 
-    SPDLOG_INFO("[VoicePack] loaded pack \"{}\": {} samples, {} vanilla ids overridden",
-                folder, pack->loadedSamples.size(), pack->sampleOverridesByVanillaSfxId.size());
+    return pack;
+}
 
-    gActivePack = std::move(pack);
+// Unload helper — drops Audio Editor display registrations + releases
+// shared_ptr<AudioSample> references. The resource cache still holds them
+// (via SetCachedResource); they'll be evicted on natural cache pressure.
+// IMPORTANT: clear the sampleByVanillaSfxId lookup BEFORE the shared_ptrs
+// drop so the audio thread can't observe a dangling Sample* through a
+// concurrent lookup.
+void UnloadPack_Locked(LoadedPack& pack) {
+    pack.sampleByVanillaSfxId.clear();
+    for (const auto& s : pack.loadedSamples) {
+        AudioCollection::Instance->RemoveCustomEntry(s.displayOnlySeqNum);
+    }
+    pack.loadedSamples.clear();  // drops shared_ptrs
 }
 
 } // namespace
@@ -315,29 +344,76 @@ void LoadPack_Locked(const std::string& folder) {
 namespace SOH {
 namespace VoicePack {
 
+struct SampleOverride {
+    SOH::Sample* sample;
+};
+static thread_local SampleOverride sLookupResult;
+
 void OnAudioModChanged(const std::string& folder) {
     std::scoped_lock lock(gStateMutex);
-    UnloadCurrentPack_Locked();
+    if (gLocalPack) {
+        SPDLOG_INFO("[VoicePack] unloading local pack \"{}\" ({} samples)",
+                    gLocalPack->folderName, gLocalPack->loadedSamples.size());
+        UnloadPack_Locked(*gLocalPack);
+        gLocalPack.reset();
+    }
     if (folder.empty()) {
-        SPDLOG_INFO("[VoicePack] Default Voices selected");
+        SPDLOG_INFO("[VoicePack] Default Voices selected (local)");
         return;
     }
-    LoadPack_Locked(folder);
+    auto pack = LoadPackFromFolder(folder);
+    if (!pack) return;
+    SPDLOG_INFO("[VoicePack] loaded LOCAL pack \"{}\": {} samples, {} vanilla ids overridden",
+                folder, pack->loadedSamples.size(), pack->sampleByVanillaSfxId.size());
+    gLocalPack = std::move(pack);
+}
+
+void OnPeerAudioModChanged(uint32_t clientId, const std::string& folder) {
+    std::scoped_lock lock(gStateMutex);
+    auto it = gPeerPacks.find(clientId);
+    if (it != gPeerPacks.end() && it->second) {
+        SPDLOG_INFO("[VoicePack] unloading peer pack clientId={} \"{}\" ({} samples)",
+                    clientId, it->second->folderName, it->second->loadedSamples.size());
+        UnloadPack_Locked(*it->second);
+        gPeerPacks.erase(it);
+    }
+    if (folder.empty()) {
+        SPDLOG_INFO("[VoicePack] Default Voices selected (peer clientId={})", clientId);
+        return;
+    }
+    auto pack = LoadPackFromFolder(folder);
+    if (!pack) return;
+    SPDLOG_INFO("[VoicePack] loaded PEER pack clientId={} \"{}\": {} samples, {} vanilla ids overridden",
+                clientId, folder, pack->loadedSamples.size(), pack->sampleByVanillaSfxId.size());
+    gPeerPacks[clientId] = std::move(pack);
+}
+
+SampleOverride* GetSampleOverride(uint16_t vanillaSfxId, uint32_t emitterClientId) {
+    std::scoped_lock lock(gStateMutex);
+
+    auto lookupInPack = [vanillaSfxId](const LoadedPack* pack) -> SOH::Sample* {
+        if (!pack) return nullptr;
+        auto it = pack->sampleByVanillaSfxId.find(vanillaSfxId);
+        return (it != pack->sampleByVanillaSfxId.end()) ? it->second : nullptr;
+    };
+
+    const uint32_t ownId = Anchor_GetLocalEmitterClientId();
+    SOH::Sample* hit = nullptr;
+    if (emitterClientId == 0 || emitterClientId == ownId) {
+        hit = lookupInPack(gLocalPack.get());
+    } else {
+        auto it = gPeerPacks.find(emitterClientId);
+        hit = lookupInPack(it != gPeerPacks.end() ? it->second.get() : nullptr);
+    }
+
+    if (hit == nullptr) return nullptr;
+    sLookupResult.sample = hit;
+    return &sLookupResult;
 }
 
 uint16_t GetReplacement(uint16_t seqId) {
-    // LEGACY — see header.  The original WIP wired this into
-    // AudioCollection::GetReplacementSequence; that direction crashed for
-    // 0xF000+ custom seqNums because the SFX dispatch path indexes the
-    // fixed-size compile-time gSoundParams[7] table (audio_sound_params.c:238).
-    //
-    // The D4+D7 substitution path consults a per-emitter sample lookup at
-    // Audio_GetSfx time on the game thread, not via this function.  Always
-    // returns 0 here; the call site in GetReplacementSequence is NOT ported
-    // from the WIP either, so nothing depends on this.  Symbol remains for
-    // ABI/link compatibility during the Phase 1–4 wire-in.
     (void)seqId;
-    return 0;
+    return 0;  // legacy stub
 }
 
 } // namespace VoicePack
@@ -345,6 +421,11 @@ uint16_t GetReplacement(uint16_t seqId) {
 
 extern "C" void VoicePack_OnAudioModChanged(const char* folder) {
     SOH::VoicePack::OnAudioModChanged(folder ? std::string(folder) : std::string());
+}
+
+extern "C" void* Anchor_GetVoiceSampleOverride(uint16_t vanillaSfxId, uint32_t emitterClientId) {
+    auto* override = SOH::VoicePack::GetSampleOverride(vanillaSfxId, emitterClientId);
+    return override ? override->sample : nullptr;
 }
 
 extern "C" uint16_t VoicePack_GetReplacement(uint16_t seqId) {

--- a/soh/soh/Enhancements/audio/VoicePack.h
+++ b/soh/soh/Enhancements/audio/VoicePack.h
@@ -18,18 +18,22 @@
 //   - D7 cache isolation: each pack's samples land under unique resource
 //     keys, mirroring BakedPlayerModel's `coopchar/<folder>/<altPath>`
 //     discipline (issue #82).
-//   - D4 substitution layer: per-emitter sample lookup table consulted at
-//     `Audio_GetSfx` time on the game thread.  Wired in Phases 1–4 of the
-//     implementation plan.
+//   - D4 substitution layer: per-emitter (clientId, vanillaSfxId) → Sample*
+//     lookup populated by the loader; consulted by the audio thread via
+//     Anchor_GetVoiceSampleOverride() at the Audio_GetSfx interception
+//     site (Phase α.4c).
 //
-// Multi-pack lifecycle (Phase 1):
-//   - Local player: load when CVAR_REMOTE_ANCHOR("AudioMod") changes.
-//   - Peer players: load when their `audioModFilename` arrives via
-//     `UPDATE_CLIENT_STATE`.
-//   - Pack swap: previous pack's resources retire via a delayed-destroy
-//     slot (mirror of BakedPlayerModel retire-slot, issue #110 / KB-15).
+// Multi-pack lifecycle:
+//   - Local player (gLocalPack): load/unload via OnAudioModChanged when
+//     CVAR_REMOTE_ANCHOR("AudioMod") changes from the dropdown.
+//   - Peer players (gPeerPacks[clientId]): load/unload via
+//     OnPeerAudioModChanged from the UPDATE_CLIENT_STATE receive handler
+//     when audioModFilename changes.
 
-#include <cstdint>
+// C-callable section below uses uint16_t / uint32_t — pull from stdint.h
+// (works in both C and C++). <cstdint> would break the C compilation of
+// code_800F7260.c which includes this header for the lookup diagnostic.
+#include <stdint.h>
 
 #ifdef __cplusplus
 #include <string>
@@ -37,20 +41,30 @@
 namespace SOH {
 namespace VoicePack {
 
-// Called from the voice-pack dropdown when CVAR_REMOTE_ANCHOR("AudioMod")
-// changes.  folder="" deselects the current local pack (Default Voices).
-//
-// Phase 0 (this commit): single-pack model inherited from the WIP scaffolding.
-// Phase 1 will introduce the (clientId → pack) map so peer packs and the
-// local pack coexist.
+// Local-player pack lifecycle. folder="" deselects (Default Voices).
+// Called from the Flotilla → Player → Voice Pack dropdown change handler.
 void OnAudioModChanged(const std::string& folder);
 
-// LEGACY / STUB — do not consume.  The original WIP wired this into
-// AudioCollection::GetReplacementSequence, which crashed for custom seqNums
-// past the 7-bank limit (see analysis doc §2).  Always returns 0 now.  Kept
-// as a named symbol only to preserve link-compatibility with code that may
-// still reference it during the D4+D7 wire-in.  Will be removed at end of
-// Phase 4 once the new substitution layer fully replaces it.
+// Peer pack lifecycle. folder="" unloads peer's pack. Called from the
+// UPDATE_CLIENT_STATE receive handler when a remote client's
+// audioModFilename changes.
+void OnPeerAudioModChanged(uint32_t clientId, const std::string& folder);
+
+// Game-thread lookup (mutex-protected). Returns the pack's Sample* for
+// the given (emitterClientId, vanillaSfxId) or nullptr if no override.
+//   - emitterClientId == 0 → no Anchor context; falls back to gLocalPack
+//     (single-player default-voice swap still works).
+//   - emitterClientId == ownClientId → gLocalPack
+//   - emitterClientId != ownClientId → gPeerPacks[emitterClientId]
+//
+// Audio-thread callers must go through Anchor_GetVoiceSampleOverride
+// below (the void* C-linkage shim) to avoid pulling SOH::Sample into the
+// C decomp side.
+struct SampleOverride;  // forward — opaque to the audio thread.
+SampleOverride* GetSampleOverride(uint16_t vanillaSfxId, uint32_t emitterClientId);
+
+// LEGACY / STUB — kept for ABI compat during Phase α wire-in. See header.
+// Always returns 0; the new substitution path is GetSampleOverride above.
 uint16_t GetReplacement(uint16_t seqId);
 
 } // namespace VoicePack
@@ -61,9 +75,18 @@ uint16_t GetReplacement(uint16_t seqId);
 extern "C" {
 #endif
 
-// C-callable façade.  Used by the SohMenu dropdown change handler.
-void     VoicePack_OnAudioModChanged(const char* folder);
-// LEGACY — see SOH::VoicePack::GetReplacement above.  Always returns 0.
+// C-callable: voice-pack dropdown change handler.
+void VoicePack_OnAudioModChanged(const char* folder);
+
+// C-callable: returns the override SoundFontSample* (as void*) for the
+// given vanilla sfxId + emitter, or NULL for vanilla fallback. Game-thread
+// safe; audio thread can also call but acquires the substitution-table
+// mutex. The audio-thread caller casts the returned void* to
+// SoundFontSample* — same memory layout as SOH::Sample (verified via
+// AudioSample.h:22 + z64audio.h:140 cross-reference).
+void* Anchor_GetVoiceSampleOverride(uint16_t vanillaSfxId, uint32_t emitterClientId);
+
+// LEGACY — see SOH::VoicePack::GetReplacement above. Always returns 0.
 uint16_t VoicePack_GetReplacement(uint16_t seqId);
 
 #ifdef __cplusplus

--- a/soh/soh/Enhancements/audio/VoicePack.h
+++ b/soh/soh/Enhancements/audio/VoicePack.h
@@ -1,0 +1,73 @@
+#ifndef SOH_ENHANCEMENTS_AUDIO_VOICE_PACK_H
+#define SOH_ENHANCEMENTS_AUDIO_VOICE_PACK_H
+
+// Voice-pack loader (B2) — issues #83 / #84.
+//
+// Manages per-player Link voice samples in multiplayer.  Each client picks a
+// VRP ("Voice Replacement Pack") folder under `player-voices/<PackFolder>/`;
+// loader scans the folder's `.otr`/`.o2r` archives, opens transiently, reads
+// every `audio/samples/<VRP label>_META` entry, translates the VRP label via
+// `<archive>/translation.json` overlayed on
+// `player-voices/_default_translation.json` to a SoH sfxKey, and registers
+// the sample in the ResourceManager cache under a per-pack unique key
+// (`player-voices/<PackFolder>/<archive entry>`).
+//
+// Architecture: D4+D7 hybrid (see
+//   Claude/Analysis/custom_voice_path_reassessment_2026-06-17.md).
+//
+//   - D7 cache isolation: each pack's samples land under unique resource
+//     keys, mirroring BakedPlayerModel's `coopchar/<folder>/<altPath>`
+//     discipline (issue #82).
+//   - D4 substitution layer: per-emitter sample lookup table consulted at
+//     `Audio_GetSfx` time on the game thread.  Wired in Phases 1–4 of the
+//     implementation plan.
+//
+// Multi-pack lifecycle (Phase 1):
+//   - Local player: load when CVAR_REMOTE_ANCHOR("AudioMod") changes.
+//   - Peer players: load when their `audioModFilename` arrives via
+//     `UPDATE_CLIENT_STATE`.
+//   - Pack swap: previous pack's resources retire via a delayed-destroy
+//     slot (mirror of BakedPlayerModel retire-slot, issue #110 / KB-15).
+
+#include <cstdint>
+
+#ifdef __cplusplus
+#include <string>
+
+namespace SOH {
+namespace VoicePack {
+
+// Called from the voice-pack dropdown when CVAR_REMOTE_ANCHOR("AudioMod")
+// changes.  folder="" deselects the current local pack (Default Voices).
+//
+// Phase 0 (this commit): single-pack model inherited from the WIP scaffolding.
+// Phase 1 will introduce the (clientId → pack) map so peer packs and the
+// local pack coexist.
+void OnAudioModChanged(const std::string& folder);
+
+// LEGACY / STUB — do not consume.  The original WIP wired this into
+// AudioCollection::GetReplacementSequence, which crashed for custom seqNums
+// past the 7-bank limit (see analysis doc §2).  Always returns 0 now.  Kept
+// as a named symbol only to preserve link-compatibility with code that may
+// still reference it during the D4+D7 wire-in.  Will be removed at end of
+// Phase 4 once the new substitution layer fully replaces it.
+uint16_t GetReplacement(uint16_t seqId);
+
+} // namespace VoicePack
+} // namespace SOH
+#endif // __cplusplus
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// C-callable façade.  Used by the SohMenu dropdown change handler.
+void     VoicePack_OnAudioModChanged(const char* folder);
+// LEGACY — see SOH::VoicePack::GetReplacement above.  Always returns 0.
+uint16_t VoicePack_GetReplacement(uint16_t seqId);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // SOH_ENHANCEMENTS_AUDIO_VOICE_PACK_H

--- a/soh/soh/Network/Anchor/AnchorClient.h
+++ b/soh/soh/Network/Anchor/AnchorClient.h
@@ -190,6 +190,11 @@ typedef struct AnchorClient {
 
     // Multiplayer cosmetic sync
     std::string customModelFilename;                    // folder name of remote client's coop pack, or ""
+    // Voice pack selection (B1 plumbing — issue #83, #84). Folder name of
+    // remote client's voice pack under player-voices/, or "" for vanilla.
+    // B2 (local preload + per-emitter substitution) and B3 (PLAYER_SFX
+    // remote routing) layer on top of this field.
+    std::string audioModFilename;
     std::shared_ptr<SOH::Skeleton> customSkeleton;      // keeps loaded skeleton alive; nullptr = vanilla
     std::string lastAppliedModelFilename;               // folder that was last passed to ApplyCustomSkeletonToDummyPlayer;
                                                         // suppresses per-frame retries when the lookup fails

--- a/soh/soh/Network/Anchor/Bridge/AnchorCoreBridge.cpp
+++ b/soh/soh/Network/Anchor/Bridge/AnchorCoreBridge.cpp
@@ -59,6 +59,21 @@ extern "C" bool Anchor_IsCurrentRoomHost(void) {
     return ::SceneAuthority::IsMyCurrentRoomHost();
 }
 
+// Flotilla custom voice (#83/#84) — returns local player's clientId for the
+// voice-emission emitter capture in Player_PlaySfx (z_actor.c:2242). The
+// caller writes the return value into gAnchorCurrentEmitterClientId (a
+// game-thread thread-local declared in code_800F7260.c) right before
+// Audio_PlaySoundGeneral; the SoundRequest captures it; later phases thread
+// it through the audio cmd queue to drive the per-emitter sample
+// substitution lookup at the audio-thread Audio_GetSfx call site.
+//
+// Returns 0 when Anchor is not connected — preserves the vanilla code path
+// (no substitution, no overhead).
+extern "C" uint32_t Anchor_GetLocalEmitterClientId(void) {
+    if (Anchor::Instance == nullptr || !Anchor::Instance->isConnected) return 0;
+    return Anchor::Instance->ownClientId;
+}
+
 // C-callable: returns true if any DummyPlayer (remote player) is currently
 // standing on top of the given DynaPolyActor's footprint. Used by
 // `DynaPolyActor_IsPlayerOnTop` callers (Obj_Lift, etc.) to make

--- a/soh/soh/Network/Anchor/JsonConversions.hpp
+++ b/soh/soh/Network/Anchor/JsonConversions.hpp
@@ -67,6 +67,7 @@ inline void from_json(const json& j, AnchorClient& client) {
     client.sceneSpawnEpoch = j.value("sceneSpawnEpoch", (u32)0);
     client.self = j.value("self", false);
     client.customModelFilename = j.value("customModelFilename", "");
+    client.audioModFilename    = j.value("audioModFilename", "");
     client.followerActive = j.value("followerActive", false);
     client.isClimbing = j.value("isClimbing", false);
     client.isCrawling = j.value("isCrawling", false);

--- a/soh/soh/Network/Anchor/Packets/Session/AllClientState.cpp
+++ b/soh/soh/Network/Anchor/Packets/Session/AllClientState.cpp
@@ -148,6 +148,7 @@ void Anchor::HandlePacket_AllClientState(nlohmann::json payload) {
         clients[client.clientId].sceneNum = client.sceneNum;
         clients[client.clientId].entranceIndex = client.entranceIndex;
         clients[client.clientId].customModelFilename = client.customModelFilename;
+        clients[client.clientId].audioModFilename    = client.audioModFilename;
         clients[client.clientId].followerActive = client.followerActive;
         clients[client.clientId].isClimbing = client.isClimbing;
         clients[client.clientId].isCrawling = client.isCrawling;

--- a/soh/soh/Network/Anchor/Packets/Session/UpdateClientState.cpp
+++ b/soh/soh/Network/Anchor/Packets/Session/UpdateClientState.cpp
@@ -34,6 +34,19 @@ static std::string GetLocalModelFilename() {
     return std::string(chosen);
 }
 
+// B1 — voice-pack folder name the local player selected, or "" for
+// default vanilla voices. Same no-existence-check rationale as
+// GetLocalModelFilename above (VirtualBox shared-folder edge case).
+// Consumers (B2 preload, B3 PLAYER_SFX routing) read this from
+// AnchorClient on the remote side.
+static std::string GetLocalAudioModFilename() {
+    const char* chosen = CVarGetString(CVAR_REMOTE_ANCHOR("AudioMod"), "");
+    if (chosen == nullptr || chosen[0] == '\0') {
+        return "";
+    }
+    return std::string(chosen);
+}
+
 /**
  * UPDATE_CLIENT_STATE
  *
@@ -56,6 +69,13 @@ nlohmann::json Anchor::PrepClientState() {
     std::string localModel = GetLocalModelFilename();
     SPDLOG_INFO("[CoopModel] PrepClientState: customModelFilename=\"{}\"", localModel);
     payload["customModelFilename"] = localModel;
+
+    // B1 — broadcast the selected voice pack. Data plumbing only; no
+    // audio side-effect yet. B2 wires the local substitution; B3 the
+    // remote PLAYER_SFX routing.
+    std::string localAudio = GetLocalAudioModFilename();
+    SPDLOG_INFO("[CoopVoice] PrepClientState: audioModFilename=\"{}\"", localAudio);
+    payload["audioModFilename"] = localAudio;
     payload["followerActive"] = IsFollowerActive();
     payload["sceneSpawnEpoch"] = sceneSpawnEpoch;
     payload["isClimbing"] = IsLocalPlayerClimbing();
@@ -181,6 +201,20 @@ void Anchor::HandlePacket_UpdateClientState(nlohmann::json payload) {
                 if (schemaVal.is_number_integer()) {
                     clients[clientId].peerMaxSchema[type] = schemaVal.get<int>();
                 }
+            }
+        }
+
+        // B1 — record remote player's voice-pack selection. Data plumbing
+        // only: no audio path consumes this yet (B2 preloads the pack's
+        // samples + game-thread substitution; B3 remaps cross-client
+        // emissions). Logging the transition makes B2/B3 integration
+        // diagnosable later.
+        if (payload["state"].contains("audioModFilename")) {
+            std::string newAudio = payload["state"]["audioModFilename"].get<std::string>();
+            if (clients[clientId].audioModFilename != newAudio) {
+                SPDLOG_INFO("[CoopVoice] UpdateClientState clientId={}: audio \"{}\" -> \"{}\"",
+                            clientId, clients[clientId].audioModFilename, newAudio);
+                clients[clientId].audioModFilename = newAudio;
             }
         }
 

--- a/soh/soh/Network/Anchor/Packets/Session/UpdateClientState.cpp
+++ b/soh/soh/Network/Anchor/Packets/Session/UpdateClientState.cpp
@@ -2,6 +2,7 @@
 #include "soh/Network/Anchor/EnemyNetId.h"  // #243.7.2 — explicit (was transitive via Anchor.h)
 #include "soh/Network/Anchor/HorseNetId.h"  // #264 horse re-emit on scene change
 #include "soh/cvar_prefixes.h"  // CVAR_ENHANCEMENT — #264 diagnostic gate
+#include "soh/Enhancements/audio/VoicePack.h"  // #83/#84 Phase α.4 — peer pack load/unload
 #include "soh/Network/Anchor/AIDirector/Director.h"  // step 6: forward reactive events
 #include "soh/Network/Anchor/Common/ActorSyncHelpers.h"
 #include "soh/Network/Anchor/Common/ItemEligibility.h"  // Phase 2 — eligibility bitmap
@@ -204,17 +205,25 @@ void Anchor::HandlePacket_UpdateClientState(nlohmann::json payload) {
             }
         }
 
-        // B1 — record remote player's voice-pack selection. Data plumbing
-        // only: no audio path consumes this yet (B2 preloads the pack's
-        // samples + game-thread substitution; B3 remaps cross-client
-        // emissions). Logging the transition makes B2/B3 integration
-        // diagnosable later.
+        // Voice-pack peer lifecycle (#83/#84 Phase α.4). Local mirror of
+        // the peer's audioModFilename selection. On transition: load the
+        // peer's pack into gPeerPacks[clientId] (D7 cache-isolation + D4
+        // substitution-table population) so this client's audio thread can
+        // play remote voices using the sender's pack samples once Phase
+        // α.4c wires the Audio_GetSfx interception.
         if (payload["state"].contains("audioModFilename")) {
             std::string newAudio = payload["state"]["audioModFilename"].get<std::string>();
             if (clients[clientId].audioModFilename != newAudio) {
                 SPDLOG_INFO("[CoopVoice] UpdateClientState clientId={}: audio \"{}\" -> \"{}\"",
                             clientId, clients[clientId].audioModFilename, newAudio);
                 clients[clientId].audioModFilename = newAudio;
+                // Trigger peer-pack load/unload. Skip self — local pack is
+                // managed by the dropdown handler. clientId == ownClientId
+                // shouldn't happen for incoming packets in practice but
+                // guard defensively.
+                if (clientId != ownClientId) {
+                    SOH::VoicePack::OnPeerAudioModChanged(clientId, newAudio);
+                }
             }
         }
 

--- a/soh/soh/SohGui/SohMenuFlotilla.cpp
+++ b/soh/soh/SohGui/SohMenuFlotilla.cpp
@@ -2,6 +2,7 @@
 #include "SohGui.hpp"
 #include "soh/OTRGlobals.h"
 #include "soh/Enhancements/enhancementTypes.h"
+#include "soh/Enhancements/audio/VoicePack.h"
 #include "soh/Network/Anchor/Anchor.h"
 #include "soh/Network/Anchor/Common/EnforcedCVars.h"
 #include "soh/Network/Anchor/Common/NavCVars.h"
@@ -30,6 +31,25 @@ static std::vector<std::string> GetInstalledCoopModelMods_Flotilla() {
         }
     }
     return mods;
+}
+
+// Voice-pack analog of GetInstalledCoopModelMods_Flotilla.  Returns {"",
+// <FolderA>, ...} where "" represents Default Voices.  Each entry is the
+// name of a subdirectory of player-voices/ (a sibling of coopplayercharacters/
+// and mods/).  Issues #83 / #84.
+static std::vector<std::string> GetInstalledVoicePacks_Flotilla() {
+    std::vector<std::string> packs;
+    packs.push_back("");
+    std::string voicePath = Ship::Context::LocateFileAcrossAppDirs("player-voices", appShortName);
+    std::filesystem::path voiceDir(voicePath);
+    if (std::filesystem::exists(voiceDir) && std::filesystem::is_directory(voiceDir)) {
+        for (const auto& entry : std::filesystem::directory_iterator(voiceDir)) {
+            if (entry.is_directory()) {
+                packs.push_back(entry.path().filename().string());
+            }
+        }
+    }
+    return packs;
 }
 
 // AI Diagnostics — Navigation Test Harness statistics widget. Custom
@@ -188,9 +208,43 @@ void SohMenu::AddMenuFlotilla() {
             }
         });
 
-    // Voice Pack and Player Pronouns slots reserved here; backend code in
-    // SohMenuSettings.cpp is still #if 0'd pending the audio routing and
-    // verb-agreement work. Re-enable here when those land.
+    // Voice Pack — picked from player-voices/ (sibling of coopplayercharacters/).
+    // Pack swap triggers loader reload via VoicePack_OnAudioModChanged and
+    // broadcasts the selection over UPDATE_CLIENT_STATE so peers can apply
+    // per-emitter routing when their B3 receive lands.  Issues #83 / #84.
+    AddWidget(path, "Voice Pack", WIDGET_CUSTOM)
+        .HideInSearch(true)
+        .CustomFunction([](WidgetInfo& info) {
+            auto anchor = Anchor::Instance;
+            static std::vector<std::string> packs;
+            if (packs.empty()) {
+                packs = GetInstalledVoicePacks_Flotilla();
+            }
+            std::string currentPack = CVarGetString(CVAR_REMOTE_ANCHOR("AudioMod"), "");
+
+            std::vector<const char*> displayNames;
+            int currentIdx = 0;
+            for (int i = 0; i < (int)packs.size(); i++) {
+                displayNames.push_back(packs[i].empty() ? "Default Voices" : packs[i].c_str());
+                if (packs[i] == currentPack) currentIdx = i;
+            }
+
+            ImGui::Text("Voice Pack");
+            ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
+            if (ImGui::Combo("##VoicePack", &currentIdx,
+                             (const char* const*)displayNames.data(), (int)displayNames.size())) {
+                CVarSetString(CVAR_REMOTE_ANCHOR("AudioMod"), packs[currentIdx].c_str());
+                Ship::Context::GetRawInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+                // Loader reload for local pack: scans player-voices/<folder>/
+                // and registers samples in the resource cache + sequenceMap.
+                VoicePack_OnAudioModChanged(packs[currentIdx].c_str());
+                // Broadcast selection so peers' B3 receive layer (when wired)
+                // can resolve (senderClientId → audioModFilename → pack samples).
+                if (anchor && anchor->isConnected) {
+                    anchor->SendPacket_UpdateClientState();
+                }
+            }
+        });
 
     AddWidget(path, "AI Player Follower (non-host only)", WIDGET_SEPARATOR_TEXT);
 

--- a/soh/src/code/audio_playback.c
+++ b/soh/src/code/audio_playback.c
@@ -1,5 +1,6 @@
 #include "global.h"
 #include "soh/ResourceManagerHelpers.h"
+#include "soh/Enhancements/audio/VoicePack.h"  // Anchor_GetVoiceSampleOverride (#83/#84 α.4c)
 #include <libultraship/bridge.h>
 
 extern bool gUseLegacySD;
@@ -398,6 +399,69 @@ SoundFontSound* Audio_GetSfx(s32 fontId, s32 sfxId) {
     }
 
     return sfx;
+}
+
+// Flotilla custom voice (#83/#84) — Phase α.4c — per-emitter sample
+// substitution wrapper around Audio_GetSfx.
+//
+// Called on the AUDIO THREAD from audio_seqplayer.c (the only consumer of
+// Audio_GetSfx for SFX dispatch). Gate sequence:
+//
+//   1. Resolve vanilla SoundFontSound — fail fast on null (keeps vanilla
+//      error semantics; we don't substitute samples for missing sounds).
+//   2. Check channel->emitterSfxBank — 0xFF means no Anchor context (BGM
+//      channels, pre-emission state) → skip substitution.
+//   3. Voice substitution is bank-6-only (BANK_VOICE). Other banks have
+//      their own dispatch paths we don't touch.
+//   4. Reconstruct the vanilla 16-bit sfxId from (bank << 12) | localIdx.
+//      Voice vanilla sfxIds span 0x6000-0x61FF; local index is 0-0x1FF.
+//      All vanilla voice ids have bit 8 of index clear, so sfxId arg
+//      (which carries the local index) captures the full address.
+//   5. Anchor_GetVoiceSampleOverride consults the per-(emitter, vanilla
+//      sfxId) lookup table populated by VoicePack at pack load. Returns
+//      NULL if no override.
+//   6. On hit, populate the per-channel emitterOverrideSlot with the
+//      custom sample pointer + the vanilla tuning, return its address.
+//      The audio synth path reads from layer->sound = <return> just like
+//      a regular SoundFontSound — same call site, transparent swap.
+//
+// Tuning: uses vanilla sfx->tuning for the override slot. Phase α.7 will
+// honor SOH::AudioSample::tuning when the resource specifies its own
+// (per AudioSoundFontFactory.cpp:310-315 pattern). For now, custom
+// packs SHOULD ship samples with matching sample rates to vanilla
+// (32 kHz typical for OoT voice) to avoid pitch artifacts.
+SoundFontSound* Audio_GetSfxOverride(struct SequenceChannel* channel, s32 fontId, s32 sfxId) {
+    SoundFontSound* vanilla = Audio_GetSfx(fontId, sfxId);
+    if (vanilla == NULL) {
+        return NULL;
+    }
+    // Channel context guard (sentinel = no Anchor context).
+    if (channel == NULL || channel->emitterSfxBank == 0xFF) {
+        return vanilla;
+    }
+    // Phase α.4c scope: voice substitution only (BANK_VOICE == 6).
+    if (channel->emitterSfxBank != 6 /* BANK_VOICE */) {
+        return vanilla;
+    }
+    // Reconstruct the vanilla 16-bit sfxId. Voice sfxIds use the 0x6800-0x68XX
+    // family — bank bits = 6 (0x6000) AND subfamily bits = 4 (0x0800) are both
+    // implicit on the audio thread; the cmd queue only carries the low byte
+    // (entry->sfxId & 0xFF at code_800F7260.c:575). The local sfxId arg here
+    // is therefore the index portion only. All vanilla voice ids confirmed
+    // to share the 0x6800 prefix: 0x6800-0x6831 (Link) + 0x685F (Navi) per
+    // R1 enumeration. Add 0x0800 explicitly so the reconstructed value
+    // matches the substitution table's key (which was populated from
+    // FindSeqIdBySfxKey returning the full vanilla sfxId like 0x6820).
+    u16 vanillaSfxId = ((u16)channel->emitterSfxBank << 12) | 0x0800 | (sfxId & 0xFF);
+    void* customSamplePtr =
+        Anchor_GetVoiceSampleOverride(vanillaSfxId, channel->emitterClientId);
+    if (customSamplePtr == NULL) {
+        return vanilla;
+    }
+    // Hit. Populate the per-channel override slot and return its address.
+    channel->emitterOverrideSlot.sample = (SoundFontSample*)customSamplePtr;
+    channel->emitterOverrideSlot.tuning = vanilla->tuning;
+    return &channel->emitterOverrideSlot;
 }
 
 s32 Audio_SetFontInstrument(s32 instrumentType, s32 fontId, s32 index, void* value) {

--- a/soh/src/code/audio_seqplayer.c
+++ b/soh/src/code/audio_seqplayer.c
@@ -167,6 +167,7 @@ void AudioSeq_InitSequenceChannel(SequenceChannel* channel) {
     }
 
     channel->unused = false;
+    channel->emitterClientId = 0; // Flotilla #83/#84 — reset to no-Anchor default; CHAN_UPD_ANCHOR_EMITTER overwrites per emission.
     Audio_InitNoteLists(&channel->notePool);
 }
 

--- a/soh/src/code/audio_seqplayer.c
+++ b/soh/src/code/audio_seqplayer.c
@@ -167,7 +167,15 @@ void AudioSeq_InitSequenceChannel(SequenceChannel* channel) {
     }
 
     channel->unused = false;
-    channel->emitterClientId = 0; // Flotilla #83/#84 — reset to no-Anchor default; CHAN_UPD_ANCHOR_EMITTER overwrites per emission.
+    // Flotilla #83/#84 — reset Anchor emitter state. CHAN_UPD_ANCHOR_EMITTER
+    // overwrites both fields per SFX dispatch from Audio_PlayActiveSounds;
+    // emitterSfxBank = 0xFF is the sentinel for "no Anchor context" (BGM
+    // channels never receive the cmd; this protects the substitution gate
+    // at Audio_GetSfxOverride from firing on uninitialized state).
+    channel->emitterClientId = 0;
+    channel->emitterSfxBank  = 0xFF;
+    channel->emitterOverrideSlot.sample = NULL;
+    channel->emitterOverrideSlot.tuningAsU32 = 0;
     Audio_InitNoteLists(&channel->notePool);
 }
 
@@ -683,7 +691,11 @@ s32 AudioSeq_SeqLayerProcessScriptStep4(SequenceLayer* layer, s32 cmd) {
         case 1:
             layer->semitone = semitone;
             sfxId = (layer->transposition << 6) + semitone;
-            sound = Audio_GetSfx(channel->fontId, sfxId);
+            // Flotilla #83/#84 α.4c — voice-substitution wrapper. Returns
+            // vanilla when channel has no Anchor emitter context (bank=0xFF)
+            // or when the substitution table has no override for the
+            // (emitterClientId, vanillaSfxId) pair. See audio_playback.c.
+            sound = Audio_GetSfxOverride(channel, channel->fontId, sfxId);
             if (sound == NULL) {
                 layer->stopSomething = true;
                 layer->delay2 = layer->delay + 1;

--- a/soh/src/code/code_800E4FE0.c
+++ b/soh/src/code/code_800E4FE0.c
@@ -20,6 +20,9 @@ typedef enum {
     CHAN_UPD_UNK_20,          // 13
     CHAN_UPD_STEREO           // 14
 } ChannelUpdateType;
+// CHAN_UPD_ANCHOR_EMITTER (15) is defined in z64audio.h so code_800F7260.c
+// (the game-thread queuer) and this file (the audio-thread dispatcher) share
+// the constant. See z64audio.h for the comment.
 
 void func_800E6300(SequenceChannel* channel, AudioCmd* arg1);
 void func_800E59AC(s32 playerIdx, s32 fadeTimer);
@@ -741,6 +744,13 @@ void func_800E6300(SequenceChannel* channel, AudioCmd* cmd) {
             return;
         case CHAN_UPD_STEREO:
             channel->stereo.asByte = cmd->asUbyte;
+            return;
+        case CHAN_UPD_ANCHOR_EMITTER:
+            // Flotilla #83/#84 — game thread queues this before each SFX
+            // playback command in Audio_PlayActiveSounds. Audio thread reads
+            // channel->emitterClientId at Audio_GetSfx interception (Phase
+            // α.4) to drive per-emitter voice-sample substitution.
+            channel->emitterClientId = cmd->data;
             return;
     }
 }

--- a/soh/src/code/code_800E4FE0.c
+++ b/soh/src/code/code_800E4FE0.c
@@ -748,9 +748,15 @@ void func_800E6300(SequenceChannel* channel, AudioCmd* cmd) {
         case CHAN_UPD_ANCHOR_EMITTER:
             // Flotilla #83/#84 — game thread queues this before each SFX
             // playback command in Audio_PlayActiveSounds. Audio thread reads
-            // channel->emitterClientId at Audio_GetSfx interception (Phase
-            // α.4) to drive per-emitter voice-sample substitution.
+            // channel->emitterClientId + channel->emitterSfxBank at
+            // Audio_GetSfxOverride interception (Phase α.4c) to drive per-
+            // emitter voice-sample substitution.
+            //
+            // - cmd->data: u32 emitter clientId
+            // - cmd->arg2: u8 bank index (0-6 for valid SFX banks; 0xFF
+            //              means "no Anchor context").
             channel->emitterClientId = cmd->data;
+            channel->emitterSfxBank  = cmd->arg2;
             return;
     }
 }

--- a/soh/src/code/code_800F7260.c
+++ b/soh/src/code/code_800F7260.c
@@ -11,7 +11,8 @@ typedef struct {
     /* 0x0C */ f32* freqScale;
     /* 0x10 */ f32* vol;
     /* 0x14 */ s8* reverbAdd;
-} SoundRequest; // size = 0x18
+    /* 0x18 */ u32 emitterClientId;  // Flotilla #83/#84 voice routing — owner of this emission, or 0 if vanilla / no Anchor context.
+} SoundRequest; // size = 0x1C
 
 typedef struct {
     /* 0x00 */ f32 value;
@@ -56,6 +57,22 @@ u8 gAudioSfxSwapMode[10];
 // sSoundRequests ring buffer endpoints. read index <= write index, wrapping around mod 256.
 u8 sSoundRequestWriteIndex = 0;
 u8 sSoundRequestReadIndex = 0;
+
+// Flotilla custom voice routing (#83/#84) — game-thread context carrying the
+// clientId of whoever's emitting the next Audio_PlaySoundGeneral. Set by
+// Player_PlaySfx (and any other voice-emission wrapper) before the call;
+// reset to 0 after. Read by Audio_PlaySoundGeneral when populating
+// SoundRequest::emitterClientId. Threaded through the audio cmd queue in
+// later phases so the audio-thread Audio_GetSfx can consult the per-emitter
+// override table.
+//
+// Plain global (not thread_local): SoH game logic is single-threaded — the
+// only other thread is the audio thread, which never reads or writes this
+// variable. Audio thread sees the value only via SoundRequest after the
+// ring-buffer enqueue happens on the game thread.
+//
+// 0 = no Anchor context / use vanilla.
+u32 gAnchorCurrentEmitterClientId = 0;
 
 /**
  * Array of pointers to arrays of SoundBankEntry of sizes: 9, 12, 22, 20, 8, 3, 5
@@ -142,6 +159,7 @@ void Audio_PlaySoundGeneral(u16 sfxId, Vec3f* pos, u8 token, f32* freqScale, f32
                         req->freqScale = freqScale;
                         req->vol = vol;
                         req->reverbAdd = reverbAdd;
+                        req->emitterClientId = gAnchorCurrentEmitterClientId; // Flotilla #83/#84
                         sSoundRequestWriteIndex++;
                         req = &sSoundRequests[sSoundRequestWriteIndex];
                     }
@@ -155,7 +173,19 @@ void Audio_PlaySoundGeneral(u16 sfxId, Vec3f* pos, u8 token, f32* freqScale, f32
         req->freqScale = freqScale;
         req->vol = vol;
         req->reverbAdd = reverbAdd;
+        req->emitterClientId = gAnchorCurrentEmitterClientId; // Flotilla #83/#84
         sSoundRequestWriteIndex++;
+
+        // Flotilla #83/#84 Phase α.1 diagnostic — log voice-bank emissions
+        // and their captured emitter context. Gated on
+        // gEnhancements.VoicePackDebugLog so it's silent in normal play.
+        // Removed when Phase α.4 substitution lands + ships clean (Phase 7
+        // cleanup pass).
+        if ((sfxId & 0xF000) == 0x6000 &&
+            CVarGetInteger(CVAR_ENHANCEMENT("VoicePackDebugLog"), 0) != 0) {
+            LUSLOG_INFO("[VoicePackEmit] sfxId=0x%04X emitterClientId=%u",
+                        sfxId, req->emitterClientId);
+        }
     }
 }
 

--- a/soh/src/code/code_800F7260.c
+++ b/soh/src/code/code_800F7260.c
@@ -587,7 +587,8 @@ void Audio_PlayActiveSounds(u8 bankId) {
                 // entry on the same round-robin channel slot.
                 Audio_QueueCmd(((u32)CHAN_UPD_ANCHOR_EMITTER << 24) |
                                 ((u32)SEQ_PLAYER_SFX << 16) |
-                                (((u32)sCurSfxPlayerChannelIdx & 0xFF) << 8),
+                                (((u32)sCurSfxPlayerChannelIdx & 0xFF) << 8) |
+                                ((u32)bankId & 0xFF),
                                 entry->emitterClientId);
                 if ((entry->sfxId & 0xF000) == 0x6000 &&
                     CVarGetInteger(CVAR_ENHANCEMENT("VoicePackDebugLog"), 0) != 0) {

--- a/soh/src/code/code_800F7260.c
+++ b/soh/src/code/code_800F7260.c
@@ -3,6 +3,7 @@
 #include "vt.h"
 
 #include "soh/Enhancements/audio/AudioEditor.h"
+#include "soh/Enhancements/audio/VoicePack.h"  // Anchor_GetVoiceSampleOverride (#83/#84 α.4)
 
 typedef struct {
     /* 0x00 */ u16 sfxId;
@@ -350,6 +351,13 @@ void Audio_ProcessSoundRequest(void) {
             CVarGetInteger(CVAR_ENHANCEMENT("VoicePackDebugLog"), 0) != 0) {
             LUSLOG_INFO("[VoicePackBank] alloc sfxId=0x%04X bank=%d entry=%d emitterClientId=%u",
                         req->sfxId, bankId, index, req->emitterClientId);
+            // Phase α.4a/b — diagnostic: confirm the substitution table
+            // would return a hit for this emission. Tests the lookup path
+            // independent of the audio-thread interception (α.4c) which
+            // is the actual playback consumer.
+            void* override = Anchor_GetVoiceSampleOverride(req->sfxId, req->emitterClientId);
+            LUSLOG_INFO("[VoicePackLookup] sfxId=0x%04X emitter=%u override=%s",
+                        req->sfxId, req->emitterClientId, override ? "FOUND" : "none");
         }
     }
 }

--- a/soh/src/code/code_800F7260.c
+++ b/soh/src/code/code_800F7260.c
@@ -570,6 +570,22 @@ void Audio_PlayActiveSounds(u8 bankId) {
                     }
                 }
                 Audio_SetSoundProperties(bankId, entryIndex, sCurSfxPlayerChannelIdx);
+                // Flotilla #83/#84 Phase α.3 — set the audio-thread channel's
+                // emitterClientId BEFORE the playback start command. Audio
+                // thread processes commands in queue order; the channel field
+                // is in place when Audio_GetSfx fires for this emission. Sent
+                // for every SFX dispatch (not just voice) so the channel's
+                // emitter state never holds stale value from a prior bank
+                // entry on the same round-robin channel slot.
+                Audio_QueueCmd(((u32)CHAN_UPD_ANCHOR_EMITTER << 24) |
+                                ((u32)SEQ_PLAYER_SFX << 16) |
+                                (((u32)sCurSfxPlayerChannelIdx & 0xFF) << 8),
+                                entry->emitterClientId);
+                if ((entry->sfxId & 0xF000) == 0x6000 &&
+                    CVarGetInteger(CVAR_ENHANCEMENT("VoicePackDebugLog"), 0) != 0) {
+                    LUSLOG_INFO("[VoicePackChan] queued sfxId=0x%04X channel=%d emitterClientId=%u",
+                                entry->sfxId, sCurSfxPlayerChannelIdx, entry->emitterClientId);
+                }
                 Audio_QueueCmdS8(0x6 << 24 | SEQ_PLAYER_SFX << 16 | ((sCurSfxPlayerChannelIdx & 0xFF) << 8), 1);
                 Audio_QueueCmdS8(0x6 << 24 | SEQ_PLAYER_SFX << 16 | ((sCurSfxPlayerChannelIdx & 0xFF) << 8) | 4,
                                  entry->sfxId & 0xFF);

--- a/soh/src/code/code_800F7260.c
+++ b/soh/src/code/code_800F7260.c
@@ -307,6 +307,12 @@ void Audio_ProcessSoundRequest(void) {
                     gSoundBanks[bankId][index].reverbAdd = req->reverbAdd;
                     gSoundBanks[bankId][index].sfxParams = soundParams->params;
                     gSoundBanks[bankId][index].sfxImportance = soundParams->importance;
+                    gSoundBanks[bankId][index].emitterClientId = req->emitterClientId; // Flotilla #83/#84 α.2
+                    if ((req->sfxId & 0xF000) == 0x6000 &&
+                        CVarGetInteger(CVAR_ENHANCEMENT("VoicePackDebugLog"), 0) != 0) {
+                        LUSLOG_INFO("[VoicePackBank] refresh sfxId=0x%04X bank=%d entry=%d emitterClientId=%u",
+                                    req->sfxId, bankId, index, req->emitterClientId);
+                    }
                 } else if (gSoundBanks[bankId][index].state == SFX_STATE_PLAYING_2) {
                     gSoundBanks[bankId][index].state = SFX_STATE_PLAYING_1;
                 }
@@ -333,12 +339,18 @@ void Audio_ProcessSoundRequest(void) {
         entry->sfxId = req->sfxId;
         entry->state = SFX_STATE_QUEUED;
         entry->freshness = 2;
+        entry->emitterClientId = req->emitterClientId; // Flotilla #83/#84 α.2
         entry->prev = sSoundBankListEnd[bankId];
         gSoundBanks[bankId][sSoundBankListEnd[bankId]].next = sSoundBankFreeListStart[bankId];
         sSoundBankListEnd[bankId] = sSoundBankFreeListStart[bankId];
         sSoundBankFreeListStart[bankId] = gSoundBanks[bankId][sSoundBankFreeListStart[bankId]].next;
         gSoundBanks[bankId][sSoundBankFreeListStart[bankId]].prev = 0xFF;
         entry->next = 0xFF;
+        if ((req->sfxId & 0xF000) == 0x6000 &&
+            CVarGetInteger(CVAR_ENHANCEMENT("VoicePackDebugLog"), 0) != 0) {
+            LUSLOG_INFO("[VoicePackBank] alloc sfxId=0x%04X bank=%d entry=%d emitterClientId=%u",
+                        req->sfxId, bankId, index, req->emitterClientId);
+        }
     }
 }
 

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -2239,7 +2239,22 @@ void func_8002F7A0(PlayState* play, Actor* actor, f32 arg2, s16 arg3, f32 arg4) 
     func_8002F758(play, actor, arg2, arg3, arg4, 0);
 }
 
+// Flotilla #83/#84 — Anchor-side resolver returning the clientId of whoever
+// owns this emission for voice substitution routing. Returns ownClientId for
+// local Link, 0 for non-Anchor / non-Player actors. Cross-client DummyPlayer
+// voice routing is wired in Phase α.6 (PLAYER_SFX packet).
+extern uint32_t Anchor_GetLocalEmitterClientId(void);
+
 void Player_PlaySfx(Actor* actor, u16 sfxId) {
+    // Flotilla #83/#84 — capture local-Link emitter for the SFX about to fire.
+    // Audio_PlaySoundGeneral reads gAnchorCurrentEmitterClientId into the
+    // SoundRequest; reset after the call so non-voice paths and non-Player
+    // emissions don't inherit stale emitter context. Only ACTOR_PLAYER
+    // captures non-zero; DummyPlayer / peer routing is Phase α.6 (B3).
+    if (actor->id == ACTOR_PLAYER) {
+        gAnchorCurrentEmitterClientId = Anchor_GetLocalEmitterClientId();
+    }
+
     if (actor->id != ACTOR_PLAYER || sfxId < NA_SE_VO_LI_SWORD_N || sfxId > NA_SE_VO_LI_ELECTRIC_SHOCK_LV_KID) {
         Audio_PlaySoundGeneral(sfxId, &actor->projectedPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
                                &gSfxDefaultReverb);
@@ -2253,6 +2268,10 @@ void Player_PlaySfx(Actor* actor, u16 sfxId) {
         Audio_PlaySoundGeneral(sfxId, &actor->projectedPos, 4, &freqMultiplier, &gSfxDefaultFreqAndVolScale,
                                &gSfxDefaultReverb);
     }
+
+    // Reset emitter context unconditionally so subsequent unrelated emissions
+    // (no matter which code path queues them) start from 0.
+    gAnchorCurrentEmitterClientId = 0;
 
     if (actor->id == ACTOR_PLAYER) {
         GameInteractor_ExecuteOnPlayerSfx(sfxId);


### PR DESCRIPTION
## Summary

Per-emitter voice-pack substitution for Link voice samples. Selected Option α (per-emitter context threading) over the original Path A/B/C survey after deep code analysis ruled them out on KISS / SoC / YAGNI / concurrency grounds. Closes most of #83 and resolves the B2 playback-path decision in #84.

Branch: 7 commits, ~880 LoC (plus the dev-mp merge bringing in #281 + #282). Audible substitution confirmed in preliminary test on `feature/custom-voice-v2`. **Three follow-ups (α.5 / α.7 / α.6) needed before this is fully usable in v1** — see "Known follow-ups" below.

## Background

The original branch `feature/player-char/custom-voice-menu-and-net-sync` (WIP commit `9d8a79e90`) was stuck after exploratory tests of `AudioCollection::GetReplacementSequence` crashed with `0xC0000005`. Deep analysis at `Claude/Analysis/custom_voice_path_reassessment_2026-06-17.md` revealed:

1. **None of Paths A/B/C had actually been attempted in code** — the crashes were tests of a different direction entirely (music-mod's seqNum-allocation pattern doesn't apply to SFX dispatch's fixed `gSoundParams[7]` table).
2. **A 4th alternative (Option α)** emerged: thread emitter context from emission site through the audio cmd queue to the audio thread's `Audio_GetSfx` call. Much smaller surface than the original 2-3 week estimates.
3. The crash class (`gSoundParams[bankIdx]` overrun with `bankIdx >= 7`) is **structurally impossible** in the D4+D7 design — substitution returns a `SoundFontSample*`, never a custom seqNum.

## Implementation (7 phase-by-phase commits)

| Commit | Phase | Scope |
|---|---|---|
| `eb44d7d98` | Phase 0 | B1 wire plumbing port + VoicePack loader port + Flotilla → Player UI |
| `1878c3889` | API drift fix | `Ship::Context::GetInstance()` → `GetRawInstance()` |
| `092607d1e` | α.1 | `SoundRequest::emitterClientId` capture from `Player_PlaySfx` |
| `f57fa1d3a` | α.2 | `SoundBankEntry::emitterClientId` propagation |
| `c4c41e363` | α.3 | `CHAN_UPD_ANCHOR_EMITTER` audio-cmd opcode + `SequenceChannel::emitterClientId` |
| `a70f5af32` | α.4a/b | Multi-pack VoicePack (`gLocalPack` + `gPeerPacks[clientId]`) + lookup API + peer-pack auto-load from `UPDATE_CLIENT_STATE` |
| `619d46967` | α.4c | `Audio_GetSfxOverride` audio-thread interception with per-channel scratch slot |

Each phase passed acceptance via diagnostic logs gated on `gEnhancements.VoicePackDebugLog` (5 phases × 7 smoke tests, logs 556-564).

## Architecture

```
game thread:
  Player_PlaySfx (z_actor.c)
    → gAnchorCurrentEmitterClientId = Anchor_GetLocalEmitterClientId()
    → Audio_PlaySoundGeneral
        → SoundRequest.emitterClientId
  Audio_ProcessSoundRequest
    → SoundBankEntry.emitterClientId
  Audio_PlayActiveSounds
    → Audio_QueueCmd(CHAN_UPD_ANCHOR_EMITTER, arg2=bankId, data=clientId)
    → Audio_QueueCmdS8(start playback)

  ━━━━ audio cmd queue ━━━━

audio thread:
  func_800E6300 case CHAN_UPD_ANCHOR_EMITTER:
    channel->emitterClientId = clientId
    channel->emitterSfxBank  = bankId
  audio_seqplayer.c:698 case 1 (SFX dispatch):
    sound = Audio_GetSfxOverride(channel, fontId, sfxId)
      → if (channel->emitterSfxBank == 6 /* voice */) {
          vanillaSfxId = 0x6000 | 0x0800 | (sfxId & 0xFF)
          customSample = Anchor_GetVoiceSampleOverride(vanillaSfxId, channel->emitterClientId)
          if (customSample) {
            channel->emitterOverrideSlot = { customSample, vanillaTuning }
            return &channel->emitterOverrideSlot   ← audio swap
          }
        }
      → return vanilla
  layer->sound = <returned SoundFontSound*>
```

Samples cache under `player-voices/<folder>/<archive entry>` keys mirroring BakedPlayerModel's `coopchar/<folder>/<altPath>` discipline (#82 precedent).

## What works

- Local Link voice substitution: ✓ (audible Femme Link samples play, preliminary test log 564)
- Multi-pack lifecycle: ✓ (peer pack auto-loads from `UPDATE_CLIENT_STATE.audioModFilename`)
- Pack swap mid-session: ✓ (verified across 7 smoke tests)
- No regressions in vanilla SFX, BGM, ambient, enemy sounds: ✓
- No crashes: ✓

## Known follow-ups before v1 merge

Each maps 1:1 to an observed test symptom:

| Phase | Symptom (log 564 preliminary test) | Effort | Scope |
|---|---|---|---|
| **α.5** | "Usually default Link, sometimes Femme" — intermittent | Small | Variant pool: vanilla emits multiple localId variants per logical voice; loader stores 1:1 → only last-loaded variant gets the override |
| **α.7** | "Femme audio at wrong pitch" | Small | `emitterOverrideSlot.tuning` uses vanilla's; honor `SOH::AudioSample::tuning != -1.0f` per `AudioSoundFontFactory.cpp:310-315` pattern |
| **α.6** | "Femme did not sync to P2" | Medium | New `PLAYER_SFX` packet — DummyPlayer voice on receivers currently has `emitter=0`; α.6 will tag emissions cross-client so `gPeerPacks` substitution fires |

Both α.5 + α.7 are small fixes (<100 LoC each); α.6 is the only piece large enough to consider for a follow-up PR.

## Test plan

- [x] Phase 0 — voice dropdown enumerates `player-voices/` subdirectories (log 556)
- [x] α.1 — local Link voice carries `emitterClientId = ownClientId`; non-Player emissions stay at 0 (log 558)
- [x] α.2 — emitter survives SoundRequest → SoundBankEntry copy (log 559)
- [x] α.3 — emitter reaches audio-thread channel via `CHAN_UPD_ANCHOR_EMITTER` (log 560)
- [x] α.4a/b — substitution table populated; lookup returns FOUND when pack covers sfxId (log 561)
- [x] α.4c — audible voice substitution fires (log 562 with vanilla-subfamily fix, then log 564)
- [ ] α.5 — variant pool fix → all voice variants of a vanilla sfxId substitute consistently
- [ ] α.7 — tuning override → custom samples play at correct pitch
- [ ] α.6 — cross-client routing → P1's pack heard on P2 via DummyPlayer

## References

- `Claude/Analysis/custom_voice_path_reassessment_2026-06-17.md` — path selection rationale
- `Claude/Plans/soh_audio_engine_analysis.md` (R1) — engine factual reference (unchanged)
- `Claude/session_state.md` "Custom Player Voice" section — implementation facts including the critical 0x0800 subfamily-bit reconstruction detail (do not re-investigate)
- #83 — voice pack feature tracker
- #84 — Settings → Characters menu umbrella; B2 decision recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
